### PR TITLE
UX guard: forbid 'backend' in user-facing UI (+ friendly errors)

### DIFF
--- a/.github/workflows/ux-guard.yml
+++ b/.github/workflows/ux-guard.yml
@@ -1,0 +1,21 @@
+name: UX Guard
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'public/locales/**'
+      - 'lib/ui/**'
+      - 'scripts/forbid-words.sh'
+
+jobs:
+  ux_guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Forbid 'backend' in UX
+        run: bash scripts/forbid-words.sh
+

--- a/lib/ui/fetchJson.ts
+++ b/lib/ui/fetchJson.ts
@@ -1,0 +1,27 @@
+import { toFriendlyError } from '@/lib/ui/friendlyError'
+
+export async function fetchJson(input: RequestInfo, init: RequestInit = {}) {
+  const headers = new Headers(init.headers || {})
+  if (!headers.has('x-request-id') && 'crypto' in globalThis) {
+    // @ts-expect-error runtime guard for older environments
+    const rid = (globalThis.crypto as any)?.randomUUID?.() ?? String(Date.now())
+    headers.set('x-request-id', rid)
+  }
+
+  const res = await fetch(input, { ...init, headers })
+  let data: any = null
+  try {
+    data = await res.clone().json()
+  } catch {
+    // ignore
+  }
+
+  if (!res.ok) {
+    const fe = toFriendlyError(res, data)
+    const err = new Error(fe.title)
+    ;(err as any).friendly = fe
+    throw err
+  }
+  return data
+}
+

--- a/lib/ui/friendlyError.ts
+++ b/lib/ui/friendlyError.ts
@@ -1,0 +1,30 @@
+export type FriendlyError = {
+  title: string
+  description?: string
+  retry?: boolean
+  supportId?: string
+}
+
+export function toFriendlyError(res: Response, body?: any): FriendlyError {
+  const rid = res.headers.get('x-request-id') ?? body?.requestId ?? body?.rid
+  const supportId = rid ? `#${rid}` : undefined
+
+  switch (res.status) {
+    case 400:
+      return { title: 'Demande incomplète ou invalide.', retry: false, supportId }
+    case 401:
+      return { title: 'Vous devez vous connecter.', retry: false, supportId }
+    case 403:
+      return { title: 'Action non autorisée.', retry: false, supportId }
+    case 404:
+      return { title: 'Introuvable.', retry: false, supportId }
+    case 413:
+      return { title: 'Fichier trop volumineux.', retry: false, supportId }
+    case 429:
+      return { title: 'Trop de requêtes. Réessayez dans un instant.', retry: true, supportId }
+    default:
+      if (res.status >= 500) return { title: 'Un problème est survenu de notre côté. Réessayez.', retry: true, supportId }
+      return { title: "Impossible d’effectuer l’action.", retry: true, supportId }
+  }
+}
+

--- a/scripts/forbid-words.sh
+++ b/scripts/forbid-words.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[ux-guard] Checking for forbidden words in UX-facing code..."
+
+PATTERN='\bbackend\b|backend/'
+PATHS=(
+  'app/**'
+  'components/**'
+  'public/locales/**'
+  'lib/ui/**'
+  'docs/user-facing/**'
+)
+
+if git grep -nEi "$PATTERN" -- ${PATHS[@]} ; then
+  echo "\n❌ 'backend' mention found in UX-facing files. Please replace with user-friendly copy."
+  exit 1
+fi
+
+echo "✅ No forbidden words found."
+


### PR DESCRIPTION
Adds a CI guard to block the word 'backend' in UX-facing paths (app/**, components/**, locales/**, lib/ui/**). Includes a small UI adapter for friendly error messages and a fetch helper that propagates X-Request-Id and throws friendly errors. No changes to product copy beyond removing jargon. This PR is independent of observability runtime changes.