### PR TITLE
config: standardize base URLs to https://app.huntaze.com (+ /api)

### DIFF
--- a/.github/workflows/smoke-cin.yml
+++ b/.github/workflows/smoke-cin.yml
@@ -1,0 +1,33 @@
+name: Smoke CIN
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL of the deployed app (e.g., https://preview.vercel.app)"
+        required: true
+        type: string
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run CIN smoke test
+        run: npx playwright test tests/smoke/cin.chat.spec.ts --reporter=dot
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
+

--- a/app/api/analytics/overview/route.ts
+++ b/app/api/analytics/overview/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://app.huntaze.com/api';
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/analytics/top-hours/route.ts
+++ b/app/api/analytics/top-hours/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://app.huntaze.com/api';
 
 export async function GET(request: NextRequest) {
   const token = request.cookies.get('access_token')?.value || request.cookies.get('auth_token')?.value;

--- a/app/api/onboarding/connect-platform/route.ts
+++ b/app/api/onboarding/connect-platform/route.ts
@@ -10,7 +10,7 @@ async function handler(request: NextRequest) {
   const log = makeReqLogger({ requestId });
   try {
     const { platform, action } = await request.json();
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3002';
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.huntaze.com';
 
     if (action === 'connect') {
       const platformRoutes: Record<string, string> = {

--- a/app/r/[code]/route.ts
+++ b/app/r/[code]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://app.huntaze.com/api';
 
 export async function GET(
   request: NextRequest,

--- a/app/r/route.ts
+++ b/app/r/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://app.huntaze.com/api';
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
@@ -24,4 +24,3 @@ export async function GET(request: NextRequest) {
   // Redirect to target
   return NextResponse.redirect(to, { status: 302 });
 }
-

--- a/docs/OBS-VERIFY-EMF.md
+++ b/docs/OBS-VERIFY-EMF.md
@@ -1,0 +1,69 @@
+# Verify CloudWatch EMF metrics
+
+This guide helps verify that `withMonitoring` publishes EMF metrics and that they appear in CloudWatch under the expected namespace and dimensions.
+
+## Prerequisites
+- AWS CLI v2 configured with credentials that can read CloudWatch Logs and Metrics.
+- The service is already deployed and producing logs.
+
+## 1) Confirm EMF in Logs (optional)
+If you know your log group name (e.g., `/aws/lambda/<fn>` or custom), you can run a quick query to count EMF events.
+
+```
+LOG_GROUP="/aws/lambda/your-api-fn"  # update
+START="-30 minutes"
+END="now"
+
+aws logs start-query \
+  --log-group-name "$LOG_GROUP" \
+  --start-time $(date -v-30M +%s) \
+  --end-time $(date +%s) \
+  --query-string 'fields @timestamp, @message | filter ispresent(@aws) or ispresent(_aws) | stats count() by bin(5m)' \
+  --query-id out.json >/dev/null 2>&1 || true
+```
+
+Alternatively, use the Console: CloudWatch > Logs Insights, pick the log group and run a similar query.
+
+## 2) Metrics: HttpRequests and HttpLatencyMs
+Open CloudWatch > Metrics and search the namespace:
+- Namespace: `Hunt/CIN` (or `MONITORING_NAMESPACE` if customized)
+- Metrics: `HttpRequests` (Count), `HttpLatencyMs` (Milliseconds)
+- Dimensions: `Service`, `Route`, `Method`, `Status`
+
+With the CLI, you can list metrics and fetch recent datapoints:
+
+```
+NAMESPACE="Hunt/CIN"
+
+aws cloudwatch list-metrics \
+  --namespace "$NAMESPACE" \
+  --metric-name HttpRequests \
+  --dimensions Name=Service,Value=cin-api \
+  --recently-active PT3H
+
+# Example: get latest 5 minutes of data for a specific route
+aws cloudwatch get-metric-statistics \
+  --namespace "$NAMESPACE" \
+  --metric-name HttpLatencyMs \
+  --start-time $(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ) \
+  --end-time $(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  --period 60 \
+  --statistics Average \
+  --dimensions Name=Service,Value=cin-api Name=Route,Value=/api/cin/chat Name=Method,Value=POST \
+  --region us-east-1
+```
+
+Note: adjust region, route, and method as needed.
+
+## 3) Alarms (optional)
+Use `put-metric-alarm` to set up p95 latency or 5xx rate alarms as described in the runbook. Example p95 on `AILatencyMs` or adapt for `HttpLatencyMs`.
+
+## 4) X-Ray (optional)
+If X-Ray is enabled, verify segments/subsegments in the X-Ray console. Ensure outbound HTTP capture is on when running in production.
+
+***
+
+Troubleshooting:
+- No metrics? Ensure logs are reaching CloudWatch and EMF JSON is printed as single-line events.
+- Dimensions mismatch? Validate `Service`, `Route`, `Method`, `Status` keys exist and are strings.
+

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,4 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://app.huntaze.com/api';
 
 class ApiClient {
   private token: string | null = null;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,5 @@
 // Authentication configuration
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://app.huntaze.com/api';
 
 // OAuth URLs - Now handled by the backend
 export const getOAuthUrl = (provider: 'google') => {

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@
   publish = ".next"
 
 [build.environment]
-  NEXT_PUBLIC_API_URL = "https://api.huntaze.com"
-  NEXT_PUBLIC_APP_URL = "https://huntaze.com"
+  NEXT_PUBLIC_API_URL = "https://app.huntaze.com/api"
+  NEXT_PUBLIC_APP_URL = "https://app.huntaze.com"
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_live_51RxE912KbmGn7DBK56bX8wioig3vLUAGDKmjRScketMFKJrRYjlXWG81WJAn97opJWPd1XZVaI9VhNDejoBbvLJF00AyA6grdI"
 
 [[plugins]]

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,8 @@
   "framework": "nextjs",
   "cleanUrls": true,
   "env": {
-    "NEXT_PUBLIC_API_URL": "https://api.huntaze.com",
-    "NEXT_PUBLIC_APP_URL": "https://huntaze.com"
+    "NEXT_PUBLIC_API_URL": "https://app.huntaze.com/api",
+    "NEXT_PUBLIC_APP_URL": "https://app.huntaze.com"
   },
   "rewrites": [
     { "source": "/api/:path*", "destination": "https://api.huntaze.com/api/:path*" }


### PR DESCRIPTION
- Set NEXT_PUBLIC_APP_URL to https://app.huntaze.com in vercel.json and netlify.toml
- Set NEXT_PUBLIC_API_URL default to https://app.huntaze.com/api in client/server fallbacks
- Replace dev localhost fallbacks in a few route handlers for consistent prod behavior

Note: CloudFront/S3 still redirects /api/*; ensure /api is routed to the Next runtime for API handlers to respond.